### PR TITLE
fix: Resolve profile picture and video upload issues

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -806,7 +806,7 @@
                     // Re-render the main profile avatar on this page
                     const avatarContainer = document.getElementById('profile-avatar-container');
                     avatarContainer.innerHTML = ''; // Clear previous
-                    const newAvatar = createProfileImage(result.photo, document.getElementById('profile-name').textContent, "profile-avatar", "text-5xl");
+                    const newAvatar = createProfileImage(result.photo, document.getElementById('profile-display-name').textContent, "profile-avatar", "text-5xl");
                     avatarContainer.appendChild(newAvatar);
                     
                     // Also update the avatar in the nav modal if it's the current user's profile

--- a/server.js
+++ b/server.js
@@ -980,10 +980,10 @@ app.post('/api/posts', isAuthenticated, postAttachmentUpload.array('attachments'
           await new Promise((resolve, reject) => {
             ffmpeg(file.path)
               .outputOptions([
-                '-vf', 'format=yuv420p,scale=1280:-2',
+                '-vf', 'scale=min(1280\\,iw):-2,format=yuv420p',
                 '-c:v', 'libx264',
-                '-pix_fmt', 'yuv420p',
-                '-r', '30',
+                '-preset', 'veryfast',
+                '-crf', '23',
                 '-movflags', '+faststart',
                 '-c:a', 'aac'
               ])
@@ -991,8 +991,10 @@ app.post('/api/posts', isAuthenticated, postAttachmentUpload.array('attachments'
                 console.log('✅ Transcode complete:', outputPath);
                 resolve(outputPath);
               })
-              .on('error', (err) => {
-                console.error('❌ FFmpeg error:', err);
+              .on('error', (err, stdout, stderr) => {
+                console.error('❌ FFmpeg error:', err.message);
+                console.error('FFmpeg stdout:', stdout);
+                console.error('FFmpeg stderr:', stderr);
                 reject(err);
               })
               .save(outputPath);


### PR DESCRIPTION
This commit addresses two bugs:

1.  A frontend bug in `profile.html` that prevented you from updating your profile picture. The bug was caused by an incorrect element ID being used to reference the user's display name.

2.  A backend issue in `server.js` that caused video uploads to fail. The `ffmpeg` command has been made more robust to handle various video inputs and prevent common errors.